### PR TITLE
PHAIN-123: Add HTTP_PROXY environment variable to run command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ k6 run \
   -e TEST_CLIENT_LOGIN_URL=${TEST_CLIENT_LOGIN_URL} \
   -e TEST_CLIENT_APP_ID=${TEST_CLIENT_APP_ID} \
   -e TEST_CLIENT_SECRET=${TEST_CLIENT_SECRET} \
+  -e HTTP_PROXY=localhost:3128 \
   ${K6_HOME}/src/tests/updates.js \
   --summary-export=${K6_SUMMARY}
 test_exit_code=$?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pha-import-notifications-perf",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "description": "Performance tests for PHA import notifications.",
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",


### PR DESCRIPTION
Environment variable `HTTP_PROXY` is required in order to access the OAuth token URL in build.