### PR TITLE
PHAIN-123: Remove HTTP_PROXY environment variable from run command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,6 @@ k6 run \
   -e TEST_CLIENT_LOGIN_URL=${TEST_CLIENT_LOGIN_URL} \
   -e TEST_CLIENT_APP_ID=${TEST_CLIENT_APP_ID} \
   -e TEST_CLIENT_SECRET=${TEST_CLIENT_SECRET} \
-  -e HTTP_PROXY=localhost:3128 \
   ${K6_HOME}/src/tests/updates.js \
   --summary-export=${K6_SUMMARY}
 test_exit_code=$?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pha-import-notifications-perf",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Performance tests for PHA import notifications.",
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",


### PR DESCRIPTION
Remove `HTTP_PROXY` environment variable, CDP have now rolled this out by default (see [#353](https://github.com/DEFRA/cdp-self-service-ops/pull/353)).