### PR TITLE
PHAIN-123: Add HTTP_PROXY environment variable to run command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ k6 run \
   -e TEST_CLIENT_LOGIN_URL=${TEST_CLIENT_LOGIN_URL} \
   -e TEST_CLIENT_APP_ID=${TEST_CLIENT_APP_ID} \
   -e TEST_CLIENT_SECRET=${TEST_CLIENT_SECRET} \
+  -e HTTPS_PROXY=http://localhost:3128 \
   ${K6_HOME}/src/tests/updates.js \
   --summary-export=${K6_SUMMARY}
 test_exit_code=$?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pha-import-notifications-perf",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Performance tests for PHA import notifications.",
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",


### PR DESCRIPTION
The change rolled out by CDP [#353](https://github.com/DEFRA/cdp-self-service-ops/pull/353) isn't currently working as expected. Environment variable `HTTP_PROXY` is required in order to test access to the OAuth token URL in build. 